### PR TITLE
Added mysql docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '3.1'
+
+services:
+  db:
+    image: mysql
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_USER=test
+      - MYSQL_PASSWORD=test
+      - MYSQL_ROOT_PASSWORD=root1234
+      - MYSQL_DATABASE=test
+    volumes:
+      - ./data:/var/lib/mysql


### PR DESCRIPTION
mysql이 설치되어 있지 않다는 가정하에
`docker-compose up -d`로 mysql docker를 생성 할 수 있는
docker-compose.yml 파일을 추가 했습니다.